### PR TITLE
Remove redundant parameters from SparseSINConv

### DIFF
--- a/mp/test_molec_models.py
+++ b/mp/test_molec_models.py
@@ -124,7 +124,6 @@ def test_zinc_sparse_sin0_model_with_batching_on_proteins():
                 print(key, torch.max(torch.abs(unbatched_res[key] - batched_res[key]))))
 
 
-
 def test_ogb_sparse_sin0_model_with_batching():
     """Check this runs without errors and that batching and no batching produce the same output."""
     data_list = get_testing_complex_list()


### PR DESCRIPTION
Removes redundant parameters from `SparseSINConv`

Here's how our best ZINC model looks like. I've included only the first convolution here since they are all the same + total count. We seem to have pretty much 1M parameters. Which is way less than I thought we have. I've triggered a run on ZINC to make sure it all works fine. 

The processing time per epoch also reduced from about 20 seconds to 13 seconds. 

```
v_embed_init.weight torch.Size([28, 128])
e_embed_init.weight torch.Size([4, 128])
convs.0.mp_levels.0.msg_up_nn.1.weight torch.Size([128, 256])
convs.0.mp_levels.0.msg_up_nn.1.bias torch.Size([128])
convs.0.mp_levels.0.update_up_nn.0.weight torch.Size([128, 128])
convs.0.mp_levels.0.update_up_nn.0.bias torch.Size([128])
convs.0.mp_levels.0.update_up_nn.1.weight torch.Size([128])
convs.0.mp_levels.0.update_up_nn.1.bias torch.Size([128])
convs.0.mp_levels.0.update_up_nn.3.weight torch.Size([128, 128])
convs.0.mp_levels.0.update_up_nn.3.bias torch.Size([128])
convs.0.mp_levels.0.update_up_nn.4.weight torch.Size([128])
convs.0.mp_levels.0.update_up_nn.4.bias torch.Size([128])
convs.0.mp_levels.0.combine_nn.0.weight torch.Size([128, 128])
convs.0.mp_levels.0.combine_nn.0.bias torch.Size([128])
convs.0.mp_levels.0.combine_nn.1.weight torch.Size([128])
convs.0.mp_levels.0.combine_nn.1.bias torch.Size([128])
convs.0.mp_levels.1.update_up_nn.0.weight torch.Size([128, 128])
convs.0.mp_levels.1.update_up_nn.0.bias torch.Size([128])
convs.0.mp_levels.1.update_up_nn.1.weight torch.Size([128])
convs.0.mp_levels.1.update_up_nn.1.bias torch.Size([128])
convs.0.mp_levels.1.update_up_nn.3.weight torch.Size([128, 128])
convs.0.mp_levels.1.update_up_nn.3.bias torch.Size([128])
convs.0.mp_levels.1.update_up_nn.4.weight torch.Size([128])
convs.0.mp_levels.1.update_up_nn.4.bias torch.Size([128])
convs.0.mp_levels.1.update_faces_nn.0.weight torch.Size([128, 128])
convs.0.mp_levels.1.update_faces_nn.0.bias torch.Size([128])
convs.0.mp_levels.1.update_faces_nn.1.weight torch.Size([128])
convs.0.mp_levels.1.update_faces_nn.1.bias torch.Size([128])
convs.0.mp_levels.1.update_faces_nn.3.weight torch.Size([128, 128])
convs.0.mp_levels.1.update_faces_nn.3.bias torch.Size([128])
convs.0.mp_levels.1.update_faces_nn.4.weight torch.Size([128])
convs.0.mp_levels.1.update_faces_nn.4.bias torch.Size([128])
convs.0.mp_levels.1.combine_nn.0.weight torch.Size([128, 256])
convs.0.mp_levels.1.combine_nn.0.bias torch.Size([128])
convs.0.mp_levels.1.combine_nn.1.weight torch.Size([128])
convs.0.mp_levels.1.combine_nn.1.bias torch.Size([128])
convs.0.mp_levels.2.update_faces_nn.0.weight torch.Size([128, 128])
convs.0.mp_levels.2.update_faces_nn.0.bias torch.Size([128])
convs.0.mp_levels.2.update_faces_nn.1.weight torch.Size([128])
convs.0.mp_levels.2.update_faces_nn.1.bias torch.Size([128])
convs.0.mp_levels.2.update_faces_nn.3.weight torch.Size([128, 128])
convs.0.mp_levels.2.update_faces_nn.3.bias torch.Size([128])
convs.0.mp_levels.2.combine_nn.0.weight torch.Size([128, 128])
convs.0.mp_levels.2.combine_nn.0.bias torch.Size([128])
convs.0.mp_levels.2.combine_nn.1.weight torch.Size([128])
convs.0.mp_levels.2.combine_nn.1.bias torch.Size([128])

============= Params stats ==================
Trainable params: 1038337
Total params    : 1038337
```