### PR TITLE
Run tests periodically

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,6 +1,10 @@
 name: Build and Test
 
-on: [push]
+on:
+  push:
+  schedule:
+    # Run the tests at 00:00 each day
+    - cron: "0 0 * * *"
 
 jobs:
   build:
@@ -43,6 +47,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
+      - name: Install graph-tool
+        run: |
+          conda install -c conda-forge graph-tool==2.29
       - name: pytorch
         run: |
           pip install torch==1.7.1+cpu torchvision==0.8.2+cpu torchaudio==0.7.2 -f https://download.pytorch.org/whl/torch_stable.html
@@ -52,9 +59,6 @@ jobs:
       - name: Install pyG
         run: |
           ./pyG_install.sh cpu
-      - name: Install graph-tool
-        run: |
-          conda install -c conda-forge graph-tool==2.29
       - name: Test with pytest
         run: |
           pytest -v

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ conda activate cwn
 
 Install dependencies:
 ```shell
+sh graph-tool_install.sh
 conda install -y pytorch=1.7.0 torchvision cudatoolkit=10.2 -c pytorch
 sh pyG_install.sh cu102
 pip install -r requirements.txt
-sh graph-tool_install.sh
 ```
 
 ### Testing

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ jupyter==1.0
 matplotlib==3.3.3
 joblib==1.0.0
 networkx==2.5
-numpy==1.19.4
+numpy==1.20.3
 tqdm==4.54.1
 scikit-learn==0.23.2
 scipy==1.5.4


### PR DESCRIPTION
- Modifies the GitHub actions to run tests periodically once per day at 00:00, in addition to on every push.
- Swaps the order of the dependency installations to avoid versioning problems.  