### PR TITLE
fix graph tool segmentation fault

### DIFF
--- a/data/utils.py
+++ b/data/utils.py
@@ -1,9 +1,9 @@
+import graph_tool as gt
+import graph_tool.topology as top
 import numpy as np
 import torch
 import gudhi as gd
 import itertools
-import graph_tool as gt
-import graph_tool.topology as top
 import networkx as nx
 
 from tqdm import tqdm


### PR DESCRIPTION
This pull request fixes a SIGSEGV from graph-tool=2.44 when calling gt.stats in function cwn.data.utils.get_rings

as noted in [graph_tool doc](https://graph-tool.skewed.de/static/doc/_modules/graph_tool.html):

`# import numpy and scipy before everything to avoid weird segmentation faults`
`# depending on the order things are imported.`

I haven't run an exhaustive debugging but importing numpy or torch before graph_tool leads to a segfault while computing the rings of a graph.

This code will reproduce the error:

![Schermata 2022-05-01 alle 12 28 57](https://user-images.githubusercontent.com/34248820/166142022-2cf18277-6578-4b38-a0c4-dafe81d53d0e.png)

After changing the position of `import graph_tool as gt`

![Schermata 2022-05-01 alle 12 30 17](https://user-images.githubusercontent.com/34248820/166142060-7f945bc2-bbd9-408c-bb03-afec4b3b69b6.png)

(I set the matrix-style terminal many years ago and never changed, sorry for that ahah)
